### PR TITLE
updated docker image with specific version of PSW

### DIFF
--- a/k8s-sgxtest/Dockerfile
+++ b/k8s-sgxtest/Dockerfile
@@ -9,9 +9,18 @@ RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bio
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | tee /etc/apt/sources.list.d/msprod.list \
     && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
-## Install openenclave & openenclave platform software (psw)
+## Install openenclave & Intel SGX platform software (PSW)
+## Install PSW in specific version instead of using the latest version to avoid the compatibility issue with Intel SGX Linux Driver (DCAP driver)
+## PSW version: 2.10
+## libsgx-dcap-ql version: 1.7
 RUN apt update \
-    && apt -y install libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave gcc g++
+    && apt -y install az-dcap-client open-enclave gcc g++ \
+    libsgx-qe3-logic=1.7.100.2-bionic1 libsgx-pce-logic=1.7.100.2-bionic1 libsgx-ae-qe3=1.7.100.2-bionic1 \
+    libsgx-dcap-ql=1.7.100.2-bionic1 libsgx-dcap-ql-dev=1.7.100.2-bionic1 libsgx-ae-qve=1.7.100.2-bionic1 \
+    libsgx-ae-pce=2.10.100.2-bionic1 libsgx-ae-le=2.10.100.2-bionic1\
+    libsgx-enclave-common=2.10.100.2-bionic1 libsgx-enclave-common-dev=2.10.100.2-bionic1 \
+    libsgx-aesm-launch-plugin=2.10.100.2-bionic1 libsgx-aesm-launch-plugin=2.10.100.2-bionic1 \
+    libsgx-launch=2.10.100.2-bionic1 libsgx-epid=2.10.100.2-bionic1 libsgx-quote-ex=2.10.100.2-bionic1 libsgx-urts=2.10.100.2-bionic1
 
 ## Copy over the samples, Source openenclaverc, Set up environment variables, Make the helloworld sample
 RUN cp -R /opt/openenclave/share/openenclave/samples . \


### PR DESCRIPTION
This PR is using the specific version of PSW to replace the latest version PSW.
Current PSW version is 2.10, and one of the sub package, libsgx-dcap-ql, is in version 1.7.
To use the specific version of PSW is to avoid the compatibility issue between the latest PSW and Intel SGX Linux Driver (DCAP driver). 

Test:
Local tested in ACC VM with helloworld test, and passed.
Test Log:
`Hello world from the enclave
Enclave called into host to print: Hello World!`